### PR TITLE
version updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,21 @@
     <build>
         <plugins>
             <plugin>
+              <groupId>org.owasp</groupId>
+              <artifactId>dependency-check-maven</artifactId>
+              <version>6.0.3</version>
+                <configuration>
+                    <failBuildOnCVSS>8</failBuildOnCVSS>
+                </configuration>
+              <executions>
+                  <execution>
+                      <goals>
+                          <goal>check</goal>
+                      </goals>
+                  </execution>
+              </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
@@ -41,7 +56,7 @@
                     <dependency>
                         <groupId>net.java.dev.javacc</groupId>
                         <artifactId>javacc</artifactId>
-                        <version>7.0.4</version>
+                        <version>7.0.10</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -112,7 +127,7 @@
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>8.37</version>
+                        <version>8.38</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -306,7 +321,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
+            <version>2.8.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Signed-off-by: Axel Nennker <axel.nennker@telekom.de>

Hi,

just a few version updates of plugins and dependencies.
`mvn clean org.owasp:dependency-check-maven:6.0.3:check` shows no vulnerable dependencies.
`mvn versions:display-dependency-updates` shows no updates needed.

Please consider adding dependency-check-maven.
Feel free to edit or ignore the PR. :-) 

Thanks for providing and maintaining htmlunit-cssparser.

kind regards
Axel