### PR TITLE
Fix where the snapshot repo needs to go in the pom.xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you use maven please add:
         <version>3.6.0-SNAPSHOT</version>
     </dependency>
 
-You have to add the sonatype snapshot repository to your pom distributionManagement section also:
+You have to add the sonatype snapshot repository to your pom `repositories` section also:
 
     <repository>
         <id>OSS Sonatype snapshots</id>


### PR DESCRIPTION
`distributionManagement` is where to deploy to, while this section explains how to consume snapshots.